### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-check.yaml
+++ b/.github/workflows/ci-check.yaml
@@ -21,16 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14.0-rc.2"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       ## https://github.com/actions/checkout
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       ## https://github.com/actions/setup-python
       ## https://github.com/actions/python-versions
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -51,6 +51,10 @@ jobs:
 
       - name: Dependency check for known vulnarbilities
         run: make depcheck
+        env:
+          ## https://ossindex.sonatype.org/
+          OSS_INDEX_USER: ${{ secrets.OSS_INDEX_USER }}
+          OSS_INDEX_API_TOKEN: ${{ secrets.OSS_INDEX_API_TOKEN }}
 
       - name: Run a source code security analyzer
         run: make secscan

--- a/.github/workflows/ci-check.yaml
+++ b/.github/workflows/ci-check.yaml
@@ -1,4 +1,6 @@
 name: CI Checks
+permissions:
+  contents: read
 
 ## This workflow runs when any of the following occur:
 ## * A push is made to the main branch

--- a/.github/workflows/ci-check.yaml
+++ b/.github/workflows/ci-check.yaml
@@ -53,7 +53,9 @@ jobs:
         run: make depcheck
         env:
           ## https://ossindex.sonatype.org/
+          ## https://github.com/sonatype-nexus-community/ossindex-python/blob/main/docs/usage.rst#authenticating-to-oss-index
           OSS_INDEX_USER: ${{ secrets.OSS_INDEX_USER }}
+          OSS_INDEX_PASSWORD: ${{ secrets.OSS_INDEX_PASSWORD }}
           OSS_INDEX_API_TOKEN: ${{ secrets.OSS_INDEX_API_TOKEN }}
 
       - name: Run a source code security analyzer

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,14 @@ test: ## Test the application
 
 depcheck: ## Dependency check for known vulnarbilities
 	# Perform a scan of dependancies backed by the OSS Index
-	# Requires env vars: OSS_INDEX_USER OSS_INDEX_API_TOKEN
-	$(VENV_BIN)/jake --warn-only ddt -t STDIN
+	# Requires env vars: OSS_INDEX_USER OSS_INDEX_PASSWORD to be set
+	# TODO: Watch for an update that allows the use of a token in ossindex-python
+	# https://github.com/sonatype-nexus-community/ossindex-python/blob/main/docs/usage.rst#authenticating-to-oss-index
+	@if [ ! -f "~/.oss-index.config" ]; then \
+		echo "username: $(OSS_INDEX_USER)" > ~/.oss-index.config; \
+		echo "password: $(OSS_INDEX_PASSWORD)" >> ~/.oss-index.config; \
+	fi
+	$(VENV_BIN)/jake --warn-only ddt --input-type ENV
 
 secscan: ## Run a source code security analyzer
 	# Analyze the application files

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ test: ## Test the application
 
 depcheck: ## Dependency check for known vulnarbilities
 	# Perform a scan of dependancies backed by the OSS Index
-	$(VENV_BIN)/jake --warn-only ddt
+	# Requires env vars: OSS_INDEX_USER OSS_INDEX_API_TOKEN
+	$(VENV_BIN)/jake --warn-only ddt -t STDIN
 
 secscan: ## Run a source code security analyzer
 	# Analyze the application files


### PR DESCRIPTION
Potential fix for [https://github.com/kyoobit/python_tornado_hello_world/security/code-scanning/2](https://github.com/kyoobit/python_tornado_hello_world/security/code-scanning/2)

The best way to fix this issue is to add an explicit `permissions` key to the workflow file, restricting `contents` to `read` at the top level (outside jobs), so that all jobs in the workflow will inherit this as a default unless they need more. Since all steps in the shown workflow either clone the repository or run commands that do not require writing any repository, issue, or pull request data, the minimal permissions required are `contents: read`. To implement the fix, add the following at the root level, below the workflow name and above the `on:` block in `.github/workflows/ci-check.yaml`:
```yaml
permissions:
  contents: read
```
No extra imports, methods, or configuration changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
